### PR TITLE
Remove score button from action modal

### DIFF
--- a/troubleshooter/index.html
+++ b/troubleshooter/index.html
@@ -284,7 +284,7 @@
       <header class="mhead">
         <h3 id="modalTitle">Aktion</h3>
         <button class="close" id="modalClose" aria-label="Schließen">✕</button>
-            <button class="btn" id="scoreBtn" title="Score anzeigen" aria-label="Score anzeigen">Score anzeigen</button></header>
+      </header>
       <div class="mbody" id="modalBody"></div>
       <div class="mfoot">
         <button class="btn primary" id="modalOk">OK</button>


### PR DESCRIPTION
## Summary
- remove duplicate "Score anzeigen" button from action modal

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c69350eafc8332a382fe6aaeadbe5b