### PR TITLE
Add celebration animation on task completion

### DIFF
--- a/troubleshooter/index.html
+++ b/troubleshooter/index.html
@@ -163,6 +163,11 @@
     .scene.mini svg{max-height:160px}
     .scene.mini{margin-top:10px}
 
+    /* Celebration animation */
+    .confetti{position:fixed;inset:0;pointer-events:none;overflow:hidden;z-index:1000;}
+    .confetti-piece{position:absolute;width:8px;height:8px;background:var(--accent);animation:drop 3s linear forwards;}
+    @keyframes drop{to{transform:translateY(100vh) rotate(720deg);opacity:0;}}
+
     /* Accessibility helpers */
     [aria-live]{outline:none}
     @media (prefers-reduced-motion: reduce){
@@ -284,7 +289,7 @@
       <header class="mhead">
         <h3 id="modalTitle">Aktion</h3>
         <button class="close" id="modalClose" aria-label="Schließen">✕</button>
-            <button class="btn" id="scoreBtn" title="Score anzeigen" aria-label="Score anzeigen">Score anzeigen</button></header>
+      </header>
       <div class="mbody" id="modalBody"></div>
       <div class="mfoot">
         <button class="btn primary" id="modalOk">OK</button>
@@ -335,6 +340,7 @@
     const modalBodyEl = document.getElementById('modalBody');
     const modalOkEl = document.getElementById('modalOk');
     const modalCloseEl = document.getElementById('modalClose');
+    let celebrationEl = null;
 
     function renderMiniScene({pcOn, monitorOn, signalOk}){
       const classes = ['scene','mini'];
@@ -376,6 +382,7 @@
       modalEl.setAttribute('aria-hidden','false');
       lastFocusEl = document.activeElement;
       if(modalCloseEl) modalCloseEl.focus();
+      if(title === 'Aufgabe abgeschlossen') showCelebration();
     }
     function closeModal(){
       if(!modalEl) return;
@@ -384,6 +391,28 @@
       modalEl.classList.remove('open');
       modalEl.setAttribute('aria-hidden','true');
       if(lastFocusEl) lastFocusEl.focus();
+      hideCelebration();
+    }
+    function showCelebration(){
+      if(celebrationEl) return;
+      celebrationEl = document.createElement('div');
+      celebrationEl.className = 'confetti';
+      const colors = ['#fbbf24','#60a5fa','#22c55e','#ef4444'];
+      for(let i=0;i<60;i++){
+        const p = document.createElement('span');
+        p.className = 'confetti-piece';
+        p.style.left = Math.random()*100 + '%';
+        p.style.backgroundColor = colors[i % colors.length];
+        p.style.animationDelay = (Math.random()*2) + 's';
+        celebrationEl.appendChild(p);
+      }
+      document.body.appendChild(celebrationEl);
+    }
+    function hideCelebration(){
+      if(celebrationEl){
+        celebrationEl.remove();
+        celebrationEl = null;
+      }
     }
     if(modalOkEl) modalOkEl.addEventListener('click', closeModal);
     if(modalCloseEl) modalCloseEl.addEventListener('click', closeModal);


### PR DESCRIPTION
## Summary
- remove duplicate "Score anzeigen" button from action modal
- display confetti animation when a task is successfully completed

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c69350eafc8332a382fe6aaeadbe5b