### PR TITLE
Add scenario 4 boot troubleshooting scenario

### DIFF
--- a/troubleshooter/index.html
+++ b/troubleshooter/index.html
@@ -51,6 +51,18 @@
                 <rect x="240" y="12" width="270" height="160" rx="6" fill="none"/>
                 <text x="375" y="92" font-size="24" text-anchor="middle" style="fill:rgba(229,231,235,.88);font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace;letter-spacing:2px">NO SIGNAL</text>
               </g>
+              <g class="booterr" aria-hidden="true">
+                <rect x="240" y="12" width="270" height="160" rx="6" fill="none"/>
+                <text x="375" y="92" font-size="22" text-anchor="middle" style="fill:rgba(229,231,235,.9);font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace;letter-spacing:1.4px">NO BOOTABLE DEVICE</text>
+              </g>
+              <g class="bootmenu" aria-hidden="true">
+                <rect x="265" y="32" width="220" height="120" rx="10" class="bootmenu-bg"/>
+                <text x="375" y="58" font-size="16" text-anchor="middle" style="fill:rgba(229,231,235,.92);font-weight:600;letter-spacing:1px">BOOT MENU</text>
+                <text x="290" y="82" font-size="13" style="fill:rgba(229,231,235,.88);font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace;">▶ SSD (Windows)</text>
+                <text x="290" y="104" font-size="13" style="fill:rgba(229,231,235,.65);font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace;">  USB Device</text>
+                <text x="290" y="126" font-size="13" style="fill:rgba(229,231,235,.65);font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace;">  Network Boot</text>
+                <text x="375" y="148" font-size="11" text-anchor="middle" style="fill:rgba(229,231,235,.5);font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace;">ENTER = Start · ESC = Zurück</text>
+              </g>
               <g class="login" aria-hidden="true">
                 <!-- Größeres, gut lesbares Login-Overlay, mittig im Monitor (270×160) -->
                 <rect x="290" y="47" width="170" height="90" rx="8" class="mut" fill="none"/>
@@ -110,6 +122,7 @@
     import scenario1 from './scenario1.js';
     import scenario2 from './scenario2.js';
     import scenario3 from './scenario3.js';
+    import scenario4 from './scenario4.js';
     // --- Persistence ---
     const STORAGE_KEY = 'pctrouble_best_v2';
     const SCORES_KEY = 'pctrouble_scores_v2';
@@ -127,7 +140,23 @@
     }
 
     // --- State ---
-    const state = { levelIdx: 0, actions: [], performed: {}, currentActionId: null };
+    const state = {
+      levelIdx: 0,
+      actions: [],
+      performed: {},
+      currentActionId: null,
+      activeSet: 'A',
+      bootMenuOpen: false,
+      bootError: false,
+      usbPresent: true,
+      bootOrderChanged: false,
+      bootOrderPersisted: false,
+      actionSequence: [],
+      s4SolvedBy: null,
+      s4RemovedUsb: false,
+      s4UsedBootMenu: false,
+      s4ChangedBootOrder: false
+    };
 
     // --- DOM helpers ---
     const $ = sel => document.querySelector(sel);
@@ -304,8 +333,12 @@
     }
 
     function runAction(a){
-      if(!a) return;
+      if(!a || state.solved) return;
       state.currentActionId = a.id || null;
+      if(a.id){
+        if(!Array.isArray(state.actionSequence)) state.actionSequence = [];
+        state.actionSequence.push(a.id);
+      }
       a.effect.call(a);
       if(a.id){ state.performed[a.id] = true; }
       // If the action itself solved the scenario (e.g., Scenario 2),
@@ -373,15 +406,39 @@
     function updateScene(){
       const scene = document.querySelector('.scene');
       if(!scene) return;
-      scene.classList.remove('nosig','power-on','login');
+      scene.classList.remove('nosig','power-on','login','booterr','bootmenu');
       if(state.pcOn) scene.classList.add('power-on');
-      if(state.monitorOn && (!state.pcOn || !state.signalOk)) scene.classList.add('nosig');
-      if(state.pcOn && state.monitorOn && state.signalOk) scene.classList.add('login');
+      const L = levels && levels[state.levelIdx];
+      if(L && L.id === 'S4'){
+        if(!state.monitorOn){
+          return;
+        }
+        if(!state.bootError){
+          scene.classList.add('login');
+        } else if(state.activeSet === 'B'){
+          scene.classList.add('bootmenu');
+        } else {
+          scene.classList.add('booterr');
+        }
+      } else {
+        if(state.monitorOn && (!state.pcOn || !state.signalOk)) scene.classList.add('nosig');
+        if(state.pcOn && state.monitorOn && state.signalOk) scene.classList.add('login');
+      }
     }
 
     function renderActions(){
       actionsEl.innerHTML = '';
+      const L = levels && levels[state.levelIdx];
+      const isS4 = !!(L && L.id === 'S4');
+      const activeSet = isS4 ? (state.activeSet || 'A') : null;
+      if(isS4){
+        const label = document.createElement('div');
+        label.className = 'action-set-label';
+        label.textContent = activeSet === 'A' ? 'Set A – Basis' : 'Set B – Setup/Boot';
+        actionsEl.appendChild(label);
+      }
       [...state.actions]
+        .filter(a => !isS4 || !a.set || a.set === activeSet)
         .sort((a,b)=>parseInt(a.hotkey)-parseInt(b.hotkey))
         .forEach(a=>{
           const btn = document.createElement('button');
@@ -396,7 +453,7 @@
     }
 
     
-    function evalRankAndScore(t, n){
+function evalRankAndScore(t, n){
   var medal = 'Bronze';
   var long = 'Bronze - geloest, aber umstaendlich';
   var color = 'var(--bronze)';
@@ -405,17 +462,62 @@
   var score = medal === 'Gold' ? 100 : (medal === 'Silber' ? 70 : 40);
   return { medal: medal, long: long, color: color, score: score };
 }
-function buildEvaluationHtml(){
+function evaluateScenarioResult(){
       const t = state.time;
       const n = state.tries;
+      const L = levels && levels[state.levelIdx];
+      if(L && L.id === 'S4'){
+        const seq = Array.isArray(state.actionSequence) ? state.actionSequence.slice() : [];
+        const solvedBy = state.s4SolvedBy;
+        const matches = expected => seq.length === expected.length && expected.every((id, idx) => seq[idx] === id);
+        let medal = 'Bronze';
+        let long = 'Bronze – Fehler behoben, aber mit Umwegen.';
+        let score = 40;
+        let detailText = '';
+        if(solvedBy === 'temp-ssd' && matches(['boot-menu','boot-ssd'])){
+          medal = 'Gold';
+          long = 'Gold – Boot-Menü genutzt und temporär von der SSD gestartet.';
+          score = 100;
+          detailText = 'Pfad: Boot-Menü → SSD (temporär).';
+        } else if(solvedBy === 'usb-restart' && matches(['remove-usb','s4-restart'])){
+          medal = 'Silber';
+          long = 'Silber – USB entfernt und sauber neu gestartet.';
+          score = 70;
+          detailText = 'Pfad: USB entfernen → Neustart.';
+        } else if(solvedBy === 'bootorder-save' && matches(['boot-menu','boot-order','save-changes'])){
+          medal = 'Silber';
+          long = 'Silber – Bootreihenfolge korrigiert und gespeichert.';
+          score = 70;
+          detailText = 'Pfad: Boot-Menü → Bootreihenfolge ändern → Speichern.';
+        } else if(solvedBy === 'temp-ssd'){
+          long = 'Bronze – Boot-Menü genutzt, aber mit Umwegen.';
+          detailText = 'Pfad: Boot-Menü / SSD mit Zusatzschritten.';
+        } else if(solvedBy === 'usb-restart'){
+          long = 'Bronze – USB-Lösung, aber mit Umwegen.';
+          detailText = 'Pfad: USB + Neustart (Umwege).';
+        } else if(solvedBy === 'bootorder-save'){
+          long = 'Bronze – BIOS-Anpassung mit Umwegen.';
+          detailText = 'Pfad: Bootreihenfolge angepasst (Umwege).';
+        } else {
+          detailText = 'Pfad: Problem behoben.';
+        }
+        const color = medal === 'Gold' ? 'var(--gold)' : medal === 'Silber' ? 'var(--silver)' : 'var(--bronze)';
+        return { medal, long, color, score, detailText, time: t, tries: n };
+      }
       const ev = evalRankAndScore(t, n);
+      return { medal: ev.medal, long: ev.long, color: ev.color, score: ev.score, detailText: '', time: t, tries: n };
+    }
+function buildEvaluationHtml(){
+      const ev = evaluateScenarioResult();
       const best = loadBest();
       const bestHtml = best ? `<div class="hint" style="margin-top:8px">Bestleistung: <b>${best.time} Min / ${best.tries} Schritte</b></div>` : '';
       const dotStyle = `background: linear-gradient(180deg, ${ev.color}, ${ev.color})`;
+      const detailHtml = ev.detailText ? `<p class="hint">${ev.detailText}</p>` : '';
       return `
         <hr class="divider" aria-hidden="true" />
         <h3>AUSWERTUNG</h3>
-        <p class="hint">Zeit: <b>${t} Min</b> - Schritte: <b>${n}</b> - Punkte: <b>${ev.score}</b></p>
+        ${detailHtml}
+        <p class="hint">Zeit: <b>${ev.time} Min</b> - Schritte: <b>${ev.tries}</b> - Punkte: <b>${ev.score}</b></p>
         <div class="score">
           <span class="dot" style="${dotStyle}" aria-hidden="true"></span>
           <span>Bewertung: ${ev.long}</span>
@@ -433,6 +535,18 @@ function completionIntroHtml(){
       return '<p><b>Aufgabe abgeschlossen.</b> Quelle korrekt, Signal wiederhergestellt.</p><p>Das <b>Login</b> ist sichtbar.</p>';
     case 'M3':
       return '<p><b>Aufgabe abgeschlossen.</b> POST erfolgreich, Anzeige aktiv.</p><p>Das <b>Login</b> ist sichtbar.</p>';
+    case 'S4': {
+      switch(state.s4SolvedBy){
+        case 'temp-ssd':
+          return '<p><b>Aufgabe abgeschlossen.</b> Du hast über das Boot-Menü temporär von der SSD gestartet.</p><p>Das <b>Login</b> ist sichtbar.</p>';
+        case 'usb-restart':
+          return '<p><b>Aufgabe abgeschlossen.</b> Störende USB-Geräte entfernt und sauber neu gestartet.</p><p>Das <b>Login</b> ist sichtbar.</p>';
+        case 'bootorder-save':
+          return '<p><b>Aufgabe abgeschlossen.</b> Bootreihenfolge korrigiert und gespeichert – die SSD startet wieder automatisch.</p><p>Das <b>Login</b> ist sichtbar.</p>';
+        default:
+          return '<p><b>Aufgabe abgeschlossen.</b> Bootfehler behoben.</p><p>Das <b>Login</b> ist sichtbar.</p>';
+      }
+    }
     default:
       return '<p><b>Aufgabe geschafft.</b> PC und Monitor sind bereit.</p><p>Das <b>Login</b> ist sichtbar.</p>';
   }
@@ -456,12 +570,20 @@ function finish(success, detail){
       // Hinweis: Reset bleibt jederzeit möglich
 
       // Bewertung
-      const t = state.time;
-      const n = state.tries;
-      const ev = evalRankAndScore(t, n);
-      resultText.innerHTML = 'Zeit: <b>' + t + ' Min</b> - Schritte: <b>' + n + '</b> - Punkte: <b>' + ev.score + '</b>'; 
-      rankText.textContent = 'Bewertung: ' + ev.long; 
-      rankDot.style.background = 'linear-gradient(180deg, ' + ev.color + ', ' + ev.color + ')'; 
+      const evaluation = evaluateScenarioResult();
+      const t = evaluation.time;
+      const n = evaluation.tries;
+      const level = levels[state.levelIdx];
+      if(level && level.id === 'S4'){
+        const parts = [];
+        if(evaluation.detailText) parts.push(evaluation.detailText);
+        parts.push(`Zeit: <b>${t} Min</b> - Schritte: <b>${n}</b> - Punkte: <b>${evaluation.score}</b>`);
+        resultText.innerHTML = parts.join('<br/>');
+      } else {
+        resultText.innerHTML = 'Zeit: <b>' + t + ' Min</b> - Schritte: <b>' + n + '</b> - Punkte: <b>' + evaluation.score + '</b>';
+      }
+      rankText.textContent = 'Bewertung: ' + evaluation.long;
+      rankDot.style.background = 'linear-gradient(180deg, ' + evaluation.color + ', ' + evaluation.color + ')';
 
       // Bestleistung speichern/anzeigen (besser = weniger Zeit, bei Gleichstand weniger Schritte)
       const prev = loadBest();
@@ -470,12 +592,13 @@ function finish(success, detail){
       if (better){ saveBest(current); }
       showBest();
       // Pro-Szenario-Score speichern
-      const L = levels[state.levelIdx];
       const scores = loadScores();
-      const prevS = scores[L.id];
-      const shouldUpdate = !prevS || (ev.score > prevS.score) || (ev.score === prevS.score && (t < prevS.time || (t === prevS.time && n < prevS.tries)));
+      const prevS = level ? scores[level.id] : null;
+      const shouldUpdate = !prevS || (evaluation.score > prevS.score) || (evaluation.score === prevS.score && (t < prevS.time || (t === prevS.time && n < prevS.tries)));
       if (shouldUpdate){
-        scores[L.id] = { time: t, tries: n, rank: ev.medal, score: ev.score, updatedAt: new Date().toISOString() };
+        if(level){
+          scores[level.id] = { time: t, tries: n, rank: evaluation.medal, score: evaluation.score, updatedAt: new Date().toISOString() };
+        }
         saveScores(scores);
       }
     }
@@ -524,7 +647,7 @@ function finish(success, detail){
     }
 
     // Level definitions & loader
-    const levels = [scenario1, scenario2, scenario3];
+    const levels = [scenario1, scenario2, scenario3, scenario4];
 
     function makeActions(){
       return {
@@ -751,6 +874,281 @@ function finish(success, detail){
         }
       };
     }
+    function makeScenario4Actions(){
+      return [
+        {
+          id: 'remove-usb',
+          set: 'A',
+          label: '⏏️ USB-Sticks entfernen',
+          hotkey: '1',
+          delta: 1,
+          effect(){
+            state.time += this.delta; state.tries++;
+            pushLog(this.label, `+${this.delta} Min`);
+            const alreadyRemoved = !state.usbPresent;
+            setStatus('USB geprüft');
+            if(alreadyRemoved){
+              say('<span class="info">Keine USB-Sticks eingesteckt.</span> Der Bootfehler liegt woanders.');
+              openModal({
+                title: this.label,
+                html: '<p>Es ist kein USB-Stick eingesteckt – der Fehler bleibt bestehen.</p><p>Öffne das <b>Boot-Menü</b> oder passe die Bootreihenfolge an.</p>'
+              });
+            } else {
+              state.usbPresent = false;
+              state.s4RemovedUsb = true;
+              say('<span class="good">USB entfernt.</span> Jetzt neu starten oder das <b>Boot-Menü</b> nutzen.');
+              openModal({
+                title: this.label,
+                html: '<p>Du entfernst alle USB-Sticks. Damit stört kein externes Medium mehr.</p><p>Starte jetzt <b>neu</b> oder wähle im <b>Boot-Menü</b> die SSD.</p>'
+              });
+            }
+          }
+        },
+        {
+          id: 's4-restart',
+          set: 'A',
+          label: '🔁 Neu starten',
+          hotkey: '2',
+          delta: 2,
+          effect(){
+            state.time += this.delta; state.tries++;
+            pushLog(this.label, `+${this.delta} Min`);
+            const resolvedByUsb = !state.usbPresent;
+            const resolvedByPersist = state.bootOrderPersisted;
+            state.bootMenuOpen = false;
+            state.activeSet = 'A';
+            if(resolvedByPersist){ state.bootOrderChanged = false; }
+            updateScene();
+            if(resolvedByUsb || resolvedByPersist){
+              state.bootError = false;
+              updateScene();
+              if(resolvedByUsb){
+                state.s4SolvedBy = 'usb-restart';
+                finish(true, 'USB-Sticks entfernt – der PC startet wieder von der SSD.');
+              } else {
+                state.s4SolvedBy = 'bootorder-save';
+                finish(true, 'Gespeicherte Bootreihenfolge – SSD steht nun an erster Stelle.');
+              }
+            } else {
+              setStatus('Bootfehler bleibt');
+              say('<span class="warn">Noch kein Erfolg.</span> Der PC zeigt weiterhin <b>NO BOOTABLE DEVICE</b>.');
+              openModal({
+                title: this.label,
+                html: '<p>Nach dem Neustart erscheint weiterhin <b>NO BOOTABLE DEVICE</b>.</p><p>Öffne das <b>Boot-Menü (F12)</b> oder passe die Bootreihenfolge im BIOS an.</p>'
+              });
+            }
+          }
+        },
+        {
+          id: 's4-monitor',
+          set: 'A',
+          label: '🖥️ Monitor ein/aus',
+          hotkey: '3',
+          delta: 1,
+          effect(){
+            state.time += this.delta; state.tries++;
+            pushLog(this.label, `+${this.delta} Min`);
+            state.monitorOn = !state.monitorOn;
+            updateScene();
+            if(state.monitorOn){
+              setStatus('Monitor an');
+              say('<span class="info">Monitor eingeschaltet.</span> Bild ist da – der Fehler liegt beim Booten.');
+              openModal({
+                title: this.label,
+                html: '<p>Der Monitor ist wieder an und zeigt weiterhin <b>NO BOOTABLE DEVICE</b>.</p><p>Die Anzeige funktioniert – konzentriere dich auf Boot-Geräte.</p>'
+              });
+            } else {
+              setStatus('Monitor aus');
+              say('<span class="warn">Monitor ausgeschaltet.</span> Zum Analysieren wieder einschalten.');
+              openModal({
+                title: this.label,
+                html: '<p>Du schaltest den Monitor aus. Für die Fehlersuche brauchst du das Bild – schalte ihn wieder ein.</p>'
+              });
+            }
+          }
+        },
+        {
+          id: 's4-power',
+          set: 'A',
+          label: '🔌 Stromkette prüfen',
+          hotkey: '4',
+          delta: 1,
+          effect(){
+            state.time += this.delta; state.tries++;
+            pushLog(this.label, `+${this.delta} Min`);
+            state.pcOn = true;
+            setStatus('Strom ok');
+            say('<span class="info">Stromversorgung geprüft.</span> Alles eingeschaltet – der Fehler liegt beim Booten.');
+            openModal({
+              title: this.label,
+              html: '<p>Netzkabel und Steckdosenleiste sind in Ordnung. Der PC läuft – das Problem ist das fehlende Boot-Gerät.</p>'
+            });
+          }
+        },
+        {
+          id: 's4-signal',
+          set: 'A',
+          label: '🔗 Monitorkabel/Quelle prüfen',
+          hotkey: '5',
+          delta: 1,
+          effect(){
+            state.time += this.delta; state.tries++;
+            pushLog(this.label, `+${this.delta} Min`);
+            state.signalOk = true;
+            setStatus('Signal geprüft');
+            say('<span class="info">Signal in Ordnung.</span> Anzeige passt – jetzt Boot-Reihenfolge klären.');
+            openModal({
+              title: this.label,
+              html: '<p>Kabel und Eingang sind korrekt. Die Anzeige funktioniert – das Problem bleibt der Bootvorgang.</p>'
+            });
+          }
+        },
+        {
+          id: 'boot-menu',
+          set: 'A',
+          label: '🧭 Boot-Menü öffnen (F12)',
+          hotkey: '6',
+          delta: 1,
+          effect(){
+            state.time += this.delta; state.tries++;
+            pushLog(this.label, `+${this.delta} Min`);
+            state.activeSet = 'B';
+            state.bootMenuOpen = true;
+            state.s4UsedBootMenu = true;
+            setStatus('Boot-Menü geöffnet');
+            updateScene();
+            renderActions();
+            say('<span class="info">Boot-Menü offen.</span> Wähle jetzt die SSD – das ist schnell und reversibel.');
+            openModal({
+              title: this.label,
+              html: '<p>Du öffnest das <b>Boot-Menü</b>. Wähle die interne <b>SSD</b> als Startgerät – das wirkt sofort und ist jederzeit rückgängig.</p>'
+            });
+          }
+        },
+        {
+          id: 'boot-ssd',
+          set: 'B',
+          label: '💽 Von SSD starten (temporär)',
+          hotkey: '1',
+          delta: 1,
+          effect(){
+            state.time += this.delta; state.tries++;
+            pushLog(this.label, `+${this.delta} Min`);
+            state.bootError = false;
+            state.bootMenuOpen = false;
+            state.activeSet = 'A';
+            updateScene();
+            renderActions();
+            state.s4SolvedBy = 'temp-ssd';
+            finish(true, 'Im Boot-Menü die SSD gewählt – temporärer Start gelingt sofort.');
+          }
+        },
+        {
+          id: 'boot-order',
+          set: 'B',
+          label: '🔀 Bootreihenfolge ansehen/ändern',
+          hotkey: '2',
+          delta: 2,
+          effect(){
+            state.time += this.delta; state.tries++;
+            pushLog(this.label, `+${this.delta} Min`);
+            state.bootOrderChanged = true;
+            state.s4ChangedBootOrder = true;
+            setStatus('Bootreihenfolge angepasst');
+            say('<span class="info">Bootreihenfolge geändert.</span> Speichere die Änderung, damit sie bleibt.');
+            openModal({
+              title: this.label,
+              html: '<p>Du schiebst die <b>SSD</b> an die erste Stelle. Drücke jetzt <b>Änderungen speichern</b>, sonst bleibt alles beim Alten.</p>'
+            });
+          }
+        },
+        {
+          id: 'drive-check',
+          set: 'B',
+          label: '🧾 Laufwerke erkannt?',
+          hotkey: '3',
+          delta: 1,
+          effect(){
+            state.time += this.delta; state.tries++;
+            pushLog(this.label, `+${this.delta} Min`);
+            setStatus('Diagnose');
+            say('<span class="info">SSD vorhanden.</span> Sie erscheint im BIOS – Fehler liegt an der Startreihenfolge.');
+            openModal({
+              title: this.label,
+              html: '<p>Die interne <b>SSD</b> wird erkannt. Hardware ist ok – passe die Bootreihenfolge an oder starte direkt von der SSD.</p>'
+            });
+          }
+        },
+        {
+          id: 'secure-boot',
+          set: 'B',
+          label: '🔒 UEFI/Secure-Boot Status ansehen',
+          hotkey: '4',
+          delta: 1,
+          effect(){
+            state.time += this.delta; state.tries++;
+            pushLog(this.label, `+${this.delta} Min`);
+            setStatus('Info');
+            say('<span class="info">Nur Informationen.</span> Secure Boot ist hier nicht die Ursache.');
+            openModal({
+              title: this.label,
+              html: '<p>Du wirfst einen Blick auf UEFI/Secure Boot. Alles unauffällig – für dieses Problem nicht nötig.</p>'
+            });
+          }
+        },
+        {
+          id: 'save-changes',
+          set: 'B',
+          label: '💾 Änderungen speichern',
+          hotkey: '5',
+          delta: 2,
+          effect(){
+            state.time += this.delta; state.tries++;
+            pushLog(this.label, `+${this.delta} Min`);
+            if(state.bootOrderChanged){
+              state.bootOrderPersisted = true;
+              state.bootOrderChanged = false;
+              state.bootError = false;
+              state.activeSet = 'A';
+              state.bootMenuOpen = false;
+              updateScene();
+              renderActions();
+              state.s4SolvedBy = 'bootorder-save';
+              finish(true, 'Bootreihenfolge gespeichert – der Neustart findet die SSD automatisch.');
+            } else {
+              setStatus('Keine Änderungen');
+              say('<span class="warn">Nichts zu speichern.</span> Passe zuerst die Reihenfolge an.');
+              openModal({
+                title: this.label,
+                html: '<p>Es wurden keine Änderungen vorgenommen. Verschiebe zuerst die SSD nach oben und speichere dann.</p>'
+              });
+            }
+          }
+        },
+        {
+          id: 'exit-nosave',
+          set: 'B',
+          label: '🚪 BIOS schließen (ohne Speichern)',
+          hotkey: '6',
+          delta: 1,
+          effect(){
+            state.time += this.delta; state.tries++;
+            pushLog(this.label, `+${this.delta} Min`);
+            state.bootMenuOpen = false;
+            state.activeSet = 'A';
+            state.bootOrderChanged = false;
+            updateScene();
+            renderActions();
+            setStatus('BIOS verlassen');
+            say('<span class="warn">Keine Änderungen gespeichert.</span> Der Bootfehler bleibt bestehen.');
+            openModal({
+              title: this.label,
+              html: '<p>Du verlässt das BIOS ohne zu speichern. Der PC startet neu und zeigt wieder <b>NO BOOTABLE DEVICE</b>.</p>'
+            });
+          }
+        }
+      ];
+    }
     function getActionsForLevel(levelId){
       const A = makeActions();
       if(levelId === 'L0'){
@@ -759,6 +1157,8 @@ function finish(success, detail){
         return [A.monitorCable, A.monitorToggle, A.bios, A.cpu, A.power, A.source];
       } else if(levelId === 'M3'){
         return [A.postCheck, A.monitorToggle, A.bios, A.ramFix, A.power, A.cmosReset];
+      } else if(levelId === 'S4'){
+        return makeScenario4Actions();
       } else {
         return [A.monitorToggle, A.bios, A.power, A.network, A.cpu, A.source];
       }
@@ -775,6 +1175,17 @@ function finish(success, detail){
       state.pcOn = L.start.pcOn;
       state.monitorOn = L.start.monitorOn;
       state.signalOk = L.start.signalOk;
+      state.bootError = L.start.bootError ?? false;
+      state.activeSet = L.start.activeSet || 'A';
+      state.bootMenuOpen = !!L.start.bootMenuOpen;
+      state.usbPresent = 'usbPresent' in L.start ? L.start.usbPresent : true;
+      state.bootOrderChanged = !!L.start.bootOrderChanged;
+      state.bootOrderPersisted = !!L.start.bootOrderPersisted;
+      state.actionSequence = [];
+      state.s4SolvedBy = null;
+      state.s4RemovedUsb = false;
+      state.s4UsedBootMenu = false;
+      state.s4ChangedBootOrder = false;
 
       // Actions per Level
       state.actions = getActionsForLevel(L.id);
@@ -941,7 +1352,10 @@ function finish(success, detail){
         }
         return;
       }
-      const action = state.actions.find(a => a.hotkey === e.key);
+      const L = levels && levels[state.levelIdx];
+      const isS4 = !!(L && L.id === 'S4');
+      const activeSet = isS4 ? (state.activeSet || 'A') : null;
+      const action = state.actions.find(a => a.hotkey === e.key && (!isS4 || !a.set || a.set === activeSet));
       if(action){
         // remember which key triggered the upcoming modal (if any)
         lastHotkey = e.key;

--- a/troubleshooter/scenario4.js
+++ b/troubleshooter/scenario4.js
@@ -1,0 +1,28 @@
+export default {
+  id: 'S4',
+  name: 'No bootable device (Bootfehler)',
+  storyTitle: 'Szenario: "No bootable device" trotz Start',
+  storyText:
+    'Der PC startet, Monitor und Signal sind aktiv – doch statt Windows erscheint sofort <b>NO BOOTABLE DEVICE</b>. ' +
+    'Finde den Fehler und bringe das System wieder bis zum Login.',
+  hints: {
+    h1: '<b>Externes Medium?</b> Bootet der PC vielleicht vom falschen Gerät (USB-Stick)?',
+    h2:
+      '<ul class="hint">' +
+      '<li><b>Boot-Menü nutzen:</b> Mit F12 das richtige Startlaufwerk (SSD) wählen – reversibel und schnell.</li>' +
+      '<li><b>USB-Geräte entfernen:</b> Sticks können die Bootreihenfolge überlagern. Danach <b>neu starten</b>.</li>' +
+      '<li><b>Nur wenn nötig:</b> Bootreihenfolge im BIOS dauerhaft ändern und speichern.</li>' +
+      '</ul>'
+  },
+  start: {
+    pcOn: true,
+    monitorOn: true,
+    signalOk: true,
+    bootError: true,
+    activeSet: 'A',
+    bootMenuOpen: false,
+    usbPresent: true,
+    bootOrderChanged: false,
+    bootOrderPersisted: false
+  }
+};

--- a/troubleshooter/styles.css
+++ b/troubleshooter/styles.css
@@ -67,6 +67,7 @@ header .controls{display:flex;gap:8px;align-items:center}
 .chip strong{color:var(--ink)}
 
 .actions{display:grid;grid-template-columns:1fr 1fr;gap:12px;margin-top:12px}
+.action-set-label{grid-column:1/-1;font-size:.85rem;font-weight:600;letter-spacing:.04em;text-transform:uppercase;color:rgba(226,232,240,.82);margin-bottom:4px}
 @media (max-width:640px){.actions{grid-template-columns:1fr}}
 button.action{
   appearance:none; border:none; cursor:pointer; padding:16px 18px; border-radius:12px; text-align:left; color:var(--ink);
@@ -188,12 +189,16 @@ details[open].hintbox summary::before, details[open].didaktik summary::before{
 .scene .mutfill{fill:rgba(255,255,255,.04)}
 .scene .no-signal{display:none}
 .scene.nosig .no-signal{display:block}
+.scene .booterr,.scene .bootmenu{display:none}
+.scene.booterr .booterr{display:block}
+.scene.bootmenu .bootmenu{display:block}
 .scene .login{display:none}
 .scene.login .login{display:block}
 .scene.power-on .led{stroke: var(--good); fill: var(--good)}
 /* Screen nur sichtbar, wenn Monitor "an" (No-Signal oder Login) */
 .scene .screen{display:none}
-.scene.nosig .screen, .scene.login .screen{display:block}
+.scene.nosig .screen, .scene.login .screen, .scene.booterr .screen, .scene.bootmenu .screen{display:block}
+.scene.bootmenu .bootmenu-bg{fill:rgba(15,23,42,.94);stroke:rgba(148,163,184,.45);stroke-width:1}
 
 /* Action message */
 .action-message{display:none;margin-top:12px;background:var(--card);border:1px solid rgba(255,255,255,.16);border-radius:16px;box-shadow:var(--shadow);padding:18px}


### PR DESCRIPTION
## Summary
- add the scenario 4 module with the no bootable device storyline and initial state
- extend the troubleshooter UI logic to handle the new scenario, dual action sets, overlays and scoring logic
- style the new boot error and boot menu overlays plus the action set label

## Testing
- no automated tests available

------
https://chatgpt.com/codex/tasks/task_e_68c85c3e2188833286b4e003120a6638