### PR TITLE
Add progress reset option to troubleshooter

### DIFF
--- a/troubleshooter/index.html
+++ b/troubleshooter/index.html
@@ -294,6 +294,29 @@
     const goalBtn = document.getElementById('goalBtn');
     let scenarioActive = false;
 
+    const versionBadges = [document.getElementById('hubVerTag'), document.getElementById('verTag')];
+    versionBadges.forEach(badge => {
+      if(!badge) return;
+      badge.classList.add('badge-action');
+      badge.setAttribute('role','button');
+      badge.setAttribute('tabindex','0');
+      badge.setAttribute('title','Fortschritt zurücksetzen');
+      const label = badge.textContent ? badge.textContent.trim() : '';
+      if(label){
+        badge.setAttribute('aria-label', `Version ${label} – Fortschritt zurücksetzen`);
+      } else {
+        badge.setAttribute('aria-label', 'Fortschritt zurücksetzen');
+      }
+      const handleClick = () => resetAllProgress();
+      badge.addEventListener('click', handleClick);
+      badge.addEventListener('keydown', event => {
+        if(event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar'){
+          event.preventDefault();
+          badge.click();
+        }
+      });
+    });
+
     function createMedalBadge(rank){
       const span = document.createElement('span');
       span.className = 'hub-medal';
@@ -448,6 +471,19 @@
       showHub();
       const focusTarget = scenarioListEl && scenarioListEl.querySelector('button:not([disabled])');
       if(focusTarget) focusTarget.focus();
+    }
+
+    function resetAllProgress(){
+      const confirmed = window.confirm('Fortschritt wirklich löschen? Alle Freischaltungen, Scores und Bestleistungen werden entfernt.');
+      if(!confirmed) return;
+      try{ localStorage.removeItem(STORAGE_KEY); }catch(e){}
+      try{ localStorage.removeItem(SCORES_KEY); }catch(e){}
+      try{ localStorage.removeItem(PROGRESS_KEY); }catch(e){}
+      progress = defaultProgress();
+      saveProgress(progress);
+      showBest();
+      returnToHub();
+      window.alert('Fortschritt wurde zurückgesetzt.');
     }
 
     const hint1Html = 'Was kannst du prüfen, <b>ohne den PC zu öffnen</b>?';

--- a/troubleshooter/styles.css
+++ b/troubleshooter/styles.css
@@ -53,6 +53,8 @@ header .controls{display:flex;gap:8px;align-items:center}
 .hub-info{display:flex;gap:8px;flex-wrap:wrap;align-items:center}
 .title{font-weight:800;font-size:clamp(22px,4vw,34px);letter-spacing:.2px}
 .badge{border:1px solid rgba(255,255,255,.12);padding:6px 10px;border-radius:999px;font-size:12px;color:var(--ink-dim)}
+.badge-action{cursor:pointer;user-select:none}
+.badge-action:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
 /* Make level tag match nav button height */
 #levelTag.badge{height:var(--ctrl-size);padding:0 12px;font-size:14px;display:flex;align-items:center}
 


### PR DESCRIPTION
## Summary
- add interactive handlers to the troubleshooter version badges to offer a progress reset confirmation
- implement a reset routine that clears stored progress, scores, and best results before returning to the hub
- style the version badges for accessibility cues when used as reset controls

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d293c20abc8332a391e38118814d94