### PR TITLE
Show domain error login state for scenario 5

### DIFF
--- a/troubleshooter/index.html
+++ b/troubleshooter/index.html
@@ -81,12 +81,17 @@
                 <text x="290" y="126" font-size="13" style="fill:rgba(229,231,235,.65);font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace;">  Network Boot</text>
                 <text x="375" y="148" font-size="11" text-anchor="middle" style="fill:rgba(229,231,235,.5);font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace;">ENTER = Start · ESC = Zurück</text>
               </g>
-              <g class="login" aria-hidden="true">
+              <g class="login login-default" aria-hidden="true">
                 <!-- Größeres, gut lesbares Login-Overlay, mittig im Monitor (270×160) -->
                 <rect x="290" y="47" width="170" height="90" rx="8" class="mut" fill="none"/>
                 <text x="375" y="80" font-size="32" text-anchor="middle" style="fill:rgba(229,231,235,.95);font-weight:700">Login</text>
                 <rect x="310" y="96" width="130" height="12" rx="6" class="mut" fill="none"/>
                 <rect x="310" y="118" width="130" height="12" rx="6" class="mut" fill="none"/>
+              </g>
+              <g class="login login-domain-error" aria-hidden="true">
+                <rect x="290" y="47" width="170" height="90" rx="8" class="mut" fill="none"/>
+                <text x="375" y="82" font-size="18" text-anchor="middle" style="fill:rgba(229,231,235,.95);font-weight:700">Fehler:</text>
+                <text x="375" y="108" font-size="16" text-anchor="middle" style="fill:rgba(229,231,235,.9);font-weight:600">Domäne nicht verfügbar!</text>
               </g>
             </svg>
           </figure>
@@ -720,7 +725,7 @@
     function updateScene(){
       const scene = document.querySelector('.scene');
       if(!scene) return;
-      scene.classList.remove('nosig','power-on','login','booterr','bootmenu');
+      scene.classList.remove('nosig','power-on','login','booterr','bootmenu','domain-error');
       if(state.pcOn) scene.classList.add('power-on');
       const L = levels && levels[state.levelIdx];
       if(L && L.id === 'S4'){
@@ -736,7 +741,12 @@
         }
       } else {
         if(state.monitorOn && (!state.pcOn || !state.signalOk)) scene.classList.add('nosig');
-        if(state.pcOn && state.monitorOn && state.signalOk) scene.classList.add('login');
+        if(state.pcOn && state.monitorOn && state.signalOk){
+          scene.classList.add('login');
+          if(L && L.id === 'N1' && !state.lanConnected){
+            scene.classList.add('domain-error');
+          }
+        }
       }
     }
 
@@ -1495,6 +1505,7 @@ function finish(success, detail){
             }
             state.lanConnected = true;
             state.switchLedOn = true;
+            updateScene();
             setStatus('Netzwerk verbunden');
             say('<span class="good">Link aktiv.</span> Die Domäne ist wieder erreichbar – starte den Login neu.');
             openModal({
@@ -1547,6 +1558,7 @@ function finish(success, detail){
               setStatus('Login erfolgreich');
               say('<span class="good">Anmeldung erfolgreich.</span> Mit Netzwerkverbindung klappt der Domänen-Login wieder.');
               state.n1SolvedBy = 'network';
+              updateScene();
               finish(true, 'Netzwerkkabel korrekt angeschlossen – Domänen-Login funktioniert wieder.');
               return;
             }

--- a/troubleshooter/styles.css
+++ b/troubleshooter/styles.css
@@ -291,6 +291,9 @@ details[open].hintbox summary::before, details[open].didaktik summary::before{
 .scene.bootmenu .bootmenu{display:block}
 .scene .login{display:none}
 .scene.login .login{display:block}
+.scene.login .login-domain-error{display:none}
+.scene.login.domain-error .login-domain-error{display:block}
+.scene.login.domain-error .login-default{display:none}
 .scene.power-on .led{stroke: var(--good); fill: var(--good)}
 /* Screen nur sichtbar, wenn Monitor "an" (No-Signal oder Login) */
 .scene .screen{display:none}


### PR DESCRIPTION
## Summary
- add a dedicated domain-error login overlay for the monitor illustration
- ensure scenario 5 toggles the domain error state based on the LAN connection and refreshes when solved
- hide the default login overlay whenever the domain error view is active

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d2d205a49083329fed8687ffb8b643