### PR TITLE
Adjust scenario5 domain error message

### DIFF
--- a/troubleshooter/index.html
+++ b/troubleshooter/index.html
@@ -88,6 +88,13 @@
                 <rect x="310" y="96" width="130" height="12" rx="6" class="mut" fill="none"/>
                 <rect x="310" y="118" width="130" height="12" rx="6" class="mut" fill="none"/>
               </g>
+              <g class="domain-msg" aria-hidden="true">
+                <rect x="290" y="47" width="170" height="90" rx="8" class="mut" fill="none"/>
+                <text x="375" y="78" font-size="18" text-anchor="middle" style="fill:rgba(229,231,235,.95);font-weight:700">
+                  <tspan x="375" dy="0">Fehler:</tspan>
+                  <tspan x="375" dy="22">Domäne nicht verfügbar!</tspan>
+                </text>
+              </g>
             </svg>
           </figure>
 
@@ -720,7 +727,7 @@
     function updateScene(){
       const scene = document.querySelector('.scene');
       if(!scene) return;
-      scene.classList.remove('nosig','power-on','login','booterr','bootmenu');
+      scene.classList.remove('nosig','power-on','login','booterr','bootmenu','domain-err');
       if(state.pcOn) scene.classList.add('power-on');
       const L = levels && levels[state.levelIdx];
       if(L && L.id === 'S4'){
@@ -736,7 +743,10 @@
         }
       } else {
         if(state.monitorOn && (!state.pcOn || !state.signalOk)) scene.classList.add('nosig');
-        if(state.pcOn && state.monitorOn && state.signalOk) scene.classList.add('login');
+        if(state.pcOn && state.monitorOn && state.signalOk){
+          scene.classList.add('login');
+          if(L && L.id === 'N1') scene.classList.add('domain-err');
+        }
       }
     }
 

--- a/troubleshooter/styles.css
+++ b/troubleshooter/styles.css
@@ -291,10 +291,17 @@ details[open].hintbox summary::before, details[open].didaktik summary::before{
 .scene.bootmenu .bootmenu{display:block}
 .scene .login{display:none}
 .scene.login .login{display:block}
+.scene .domain-msg{display:none}
+.scene.domain-err .domain-msg{display:block}
+.scene.domain-err .login{display:none}
 .scene.power-on .led{stroke: var(--good); fill: var(--good)}
 /* Screen nur sichtbar, wenn Monitor "an" (No-Signal oder Login) */
 .scene .screen{display:none}
-.scene.nosig .screen, .scene.login .screen, .scene.booterr .screen, .scene.bootmenu .screen{display:block}
+.scene.nosig .screen,
+.scene.login .screen,
+.scene.booterr .screen,
+.scene.bootmenu .screen,
+.scene.domain-err .screen{display:block}
 .scene.bootmenu .bootmenu-bg{fill:rgba(15,23,42,.94);stroke:rgba(148,163,184,.45);stroke-width:1}
 
 /* Action message */


### PR DESCRIPTION
## Summary
- add a dedicated SVG overlay for scenario 5 showing the domain connectivity error message instead of the login form
- toggle a new scene state in the renderer so only scenario 5 swaps to the domain error view
- extend the styles so the login fields are hidden and the error text is shown while keeping the screen lit

## Testing
- No automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d2d205a49083329fed8687ffb8b643