### PR TITLE
Use Windows-style desktop for scenario 6 display

### DIFF
--- a/troubleshooter/index.html
+++ b/troubleshooter/index.html
@@ -53,6 +53,21 @@
 
           <figure class="scene" role="img" aria-label="PC-Tower und Monitor auf einem Schreibtisch (neutrale Ausgangslage)">
             <svg viewBox="0 0 800 220" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+              <defs>
+                <linearGradient id="desktopGradient" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0%" stop-color="#38bdf8" />
+                  <stop offset="55%" stop-color="#6366f1" />
+                  <stop offset="100%" stop-color="#312e81" />
+                </linearGradient>
+                <linearGradient id="taskbarGradient" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0%" stop-color="rgba(15,23,42,.9)" />
+                  <stop offset="100%" stop-color="rgba(15,23,42,.75)" />
+                </linearGradient>
+                <linearGradient id="windowGradient" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0%" stop-color="rgba(15,23,42,.65)" />
+                  <stop offset="100%" stop-color="rgba(15,23,42,.35)" />
+                </linearGradient>
+              </defs>
               <!-- Tischlinie -->
               <rect x="20" y="194" width="760" height="8" rx="4" class="mutfill"/>
               <rect x="20" y="194" width="760" height="8" rx="4" class="mut" fill="none"/>
@@ -99,6 +114,59 @@
                 <text x="290" y="104" font-size="13" style="fill:rgba(229,231,235,.65);font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace;">  USB Device</text>
                 <text x="290" y="126" font-size="13" style="fill:rgba(229,231,235,.65);font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace;">  Network Boot</text>
                 <text x="375" y="148" font-size="11" text-anchor="middle" style="fill:rgba(229,231,235,.5);font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace;">ENTER = Start · ESC = Zurück</text>
+              </g>
+              <g class="desktop" aria-hidden="true">
+                <rect x="247" y="19" width="256" height="146" rx="10" fill="url(#desktopGradient)"/>
+                <circle cx="402" cy="68" r="62" fill="rgba(255,255,255,.09)"/>
+                <path d="M247 132 C290 112 332 138 374 122 C412 108 456 122 503 108 L503 165 L247 165 Z" fill="rgba(15,23,42,.18)"/>
+                <rect x="338" y="45" width="146" height="86" rx="10" fill="url(#windowGradient)" stroke="rgba(148,163,184,.35)" stroke-width="1"/>
+                <rect x="338" y="45" width="146" height="20" rx="10" fill="rgba(15,23,42,.7)"/>
+                <circle cx="350" cy="55" r="3" fill="rgba(248,113,113,.9)"/>
+                <circle cx="360" cy="55" r="3" fill="rgba(251,191,36,.9)"/>
+                <circle cx="370" cy="55" r="3" fill="rgba(52,211,153,.9)"/>
+                <text x="412" y="59" font-size="11" style="fill:rgba(226,232,240,.88);font-family:'Segoe UI',sans-serif;font-weight:600">Explorer</text>
+                <rect x="348" y="74" width="62" height="10" rx="5" fill="rgba(59,130,246,.45)"/>
+                <rect x="416" y="74" width="54" height="10" rx="5" fill="rgba(248,250,252,.2)"/>
+                <rect x="348" y="92" width="122" height="8" rx="4" fill="rgba(248,250,252,.18)"/>
+                <rect x="348" y="108" width="122" height="8" rx="4" fill="rgba(248,250,252,.14)"/>
+                <rect x="348" y="124" width="92" height="8" rx="4" fill="rgba(248,250,252,.14)"/>
+                <g>
+                  <rect x="270" y="33" width="30" height="30" rx="7" fill="#2563eb" stroke="rgba(15,23,42,.3)" stroke-width="1"/>
+                  <text x="285" y="53" font-size="18" text-anchor="middle" style="fill:rgba(255,255,255,.95);font-weight:600;font-family:'Segoe UI',sans-serif">W</text>
+                  <text x="285" y="71" font-size="10" text-anchor="middle" style="fill:rgba(241,245,249,.92);font-family:'Segoe UI',sans-serif">Word</text>
+                </g>
+                <g>
+                  <rect x="270" y="79" width="30" height="30" rx="7" fill="#15803d" stroke="rgba(15,23,42,.3)" stroke-width="1"/>
+                  <text x="285" y="99" font-size="18" text-anchor="middle" style="fill:rgba(255,255,255,.95);font-weight:600;font-family:'Segoe UI',sans-serif">X</text>
+                  <text x="285" y="117" font-size="10" text-anchor="middle" style="fill:rgba(241,245,249,.92);font-family:'Segoe UI',sans-serif">Excel</text>
+                </g>
+                <g>
+                  <rect x="270" y="125" width="30" height="30" rx="7" fill="#ea580c" stroke="rgba(15,23,42,.3)" stroke-width="1"/>
+                  <text x="285" y="145" font-size="18" text-anchor="middle" style="fill:rgba(255,255,255,.95);font-weight:600;font-family:'Segoe UI',sans-serif">P</text>
+                  <text x="285" y="163" font-size="9" text-anchor="middle" style="fill:rgba(241,245,249,.92);font-family:'Segoe UI',sans-serif">PowerPoint</text>
+                </g>
+                <rect x="247" y="153" width="256" height="12" rx="6" fill="url(#taskbarGradient)"/>
+                <rect x="255" y="154" width="16" height="10" rx="3" fill="rgba(255,255,255,.12)" stroke="rgba(255,255,255,.18)" stroke-width=".6"/>
+                <path d="M258 156h4v4h-4z M264 156h4v4h-4z M258 160h4v4h-4z M264 160h4v4h-4z" fill="rgba(255,255,255,.85)"/>
+                <rect x="276" y="154" width="82" height="10" rx="5" fill="rgba(255,255,255,.12)"/>
+                <circle cx="285" cy="159" r="3" stroke="rgba(255,255,255,.45)" stroke-width="1" fill="none"/>
+                <text x="296" y="161" font-size="7" style="fill:rgba(248,250,252,.75);font-family:'Segoe UI',sans-serif">Suchen</text>
+                <rect x="366" y="154" width="10" height="10" rx="2" fill="rgba(248,250,252,.26)"/>
+                <rect x="380" y="154" width="10" height="10" rx="2" fill="rgba(96,165,250,.55)"/>
+                <rect x="394" y="154" width="10" height="10" rx="2" fill="rgba(16,185,129,.45)"/>
+                <rect x="408" y="154" width="10" height="10" rx="2" fill="rgba(244,114,182,.45)"/>
+                <rect x="394" y="163" width="10" height="2" rx="1" fill="rgba(96,165,250,.85)"/>
+                <rect x="424" y="154" width="18" height="10" rx="4" fill="rgba(148,163,184,.35)"/>
+                <path d="M429 160h8" stroke="rgba(241,245,249,.65)" stroke-width="1.4" stroke-linecap="round"/>
+                <rect x="446" y="154" width="14" height="10" rx="3" fill="rgba(255,255,255,.16)"/>
+                <path d="M448 160h6" stroke="rgba(248,250,252,.75)" stroke-width="1" stroke-linecap="round"/>
+                <path d="M451 158l2 4" stroke="rgba(248,250,252,.75)" stroke-width="1" stroke-linecap="round"/>
+                <path d="M454 158l-2 4" stroke="rgba(248,250,252,.75)" stroke-width="1" stroke-linecap="round"/>
+                <path d="M459 159c3-3 9-3 12 0" stroke="rgba(248,250,252,.7)" stroke-width="1" fill="none" stroke-linecap="round"/>
+                <path d="M462 161c2-2 6-2 8 0" stroke="rgba(248,250,252,.7)" stroke-width="1" fill="none" stroke-linecap="round"/>
+                <circle cx="466" cy="163" r="1.2" fill="rgba(248,250,252,.8)"/>
+                <rect x="468" y="154" width="32" height="10" rx="5" fill="rgba(255,255,255,.14)"/>
+                <text x="484" y="161" font-size="7" text-anchor="middle" style="fill:rgba(248,250,252,.85);font-family:'Segoe UI',sans-serif">14:22</text>
               </g>
               <g class="login login-default" aria-hidden="true">
                 <!-- Größeres, gut lesbares Login-Overlay, mittig im Monitor (270×160) -->
@@ -754,7 +822,7 @@
     function updateScene(){
       const scene = document.querySelector('.scene');
       if(!scene) return;
-      scene.classList.remove('nosig','power-on','login','booterr','bootmenu','domain-error','overheat','fan-blocked','fan-clean');
+      scene.classList.remove('nosig','power-on','login','booterr','bootmenu','domain-error','overheat','fan-blocked','fan-clean','desktop-mode');
       if(state.pcOn) scene.classList.add('power-on');
       const L = levels && levels[state.levelIdx];
       if(L && L.id === 'S4'){
@@ -771,11 +839,16 @@
       } else {
         if(state.monitorOn && (!state.pcOn || !state.signalOk)) scene.classList.add('nosig');
         if(state.pcOn && state.monitorOn && state.signalOk){
-          scene.classList.add('login');
-          if(L && L.id === 'N1' && !state.lanConnected){
-            scene.classList.add('domain-error');
+          const isS2 = L && L.id === 'S2';
+          if(isS2){
+            scene.classList.add('desktop-mode');
+          } else {
+            scene.classList.add('login');
+            if(L && L.id === 'N1' && !state.lanConnected){
+              scene.classList.add('domain-error');
+            }
           }
-          if(L && L.id === 'S2'){
+          if(isS2){
             if(state.fanBlocked){ scene.classList.add('fan-blocked'); }
             if(!state.tempsStable){ scene.classList.add('overheat'); }
             if(!state.fanBlocked && state.dustCleared){ scene.classList.add('fan-clean'); }

--- a/troubleshooter/styles.css
+++ b/troubleshooter/styles.css
@@ -290,7 +290,10 @@ details[open].hintbox summary::before, details[open].didaktik summary::before{
 .scene.booterr .booterr{display:block}
 .scene.bootmenu .bootmenu{display:block}
 .scene .login{display:none}
+.scene .desktop{display:none}
 .scene.login .login{display:block}
+.scene.desktop-mode .desktop{display:block}
+.scene.desktop-mode .screen{display:block}
 .scene.login .login-domain-error{display:none}
 .scene.login.domain-error .login-domain-error{display:block}
 .scene.login.domain-error .login-default{display:none}


### PR DESCRIPTION
## Summary
- add gradient definitions and an SVG desktop layout that mirrors a Windows 11 style background, taskbar, and Office icons for scenario 6
- introduce a dedicated `desktop-mode` scene state so the overheating scenario shows the desktop instead of the login overlay, and update styles to reveal the new art

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3f3f753b08332ac4ad416550fbe0a