### PR TITLE
Move score reset toggle into score modal header

### DIFF
--- a/troubleshooter/code/index.html
+++ b/troubleshooter/code/index.html
@@ -2685,12 +2685,26 @@ function finish(success, detail){
               </thead>
               <tbody>${rows}</tbody>
             </table>
-          </div>
-          <div class="score-modal-footer" style="display:flex;justify-content:flex-end;align-items:center;gap:8px;margin-top:12px;">
-            <button type="button" id="scoreBombToggle" class="btn" title="Löschen-Buttons einblenden" aria-label="Löschen-Buttons einblenden"><span class="emoji" aria-hidden="true">💣</span></button>
           </div>`;
         openTopModal({ title: '', subtitle, html });
         if(topModalCloseEl){ topModalCloseEl.hidden = false; }
+
+        const headerEl = topModalEl ? topModalEl.querySelector('.mhead') : null;
+        if(headerEl){
+          let bombToggle = document.getElementById('scoreBombToggle');
+          const closeBtn = (topModalCloseEl && headerEl.contains(topModalCloseEl)) ? topModalCloseEl : null;
+          if(!bombToggle){
+            bombToggle = document.createElement('button');
+            bombToggle.type = 'button';
+            bombToggle.id = 'scoreBombToggle';
+            bombToggle.innerHTML = '<span class="emoji" aria-hidden="true">💣</span>';
+          }
+          bombToggle.className = 'modal-icon-btn';
+          bombToggle.title = 'Löschen-Buttons einblenden';
+          bombToggle.setAttribute('aria-label', 'Löschen-Buttons einblenden');
+          bombToggle.setAttribute('aria-pressed', 'false');
+          headerEl.insertBefore(bombToggle, closeBtn);
+        }
 
         // Add event delegation for score reset via bomb button
         setTimeout(()=>{
@@ -2729,15 +2743,27 @@ function finish(success, detail){
             });
           }
           if(bombToggle){
-            let bombsVisible = false;
-            bombToggle.addEventListener('click', function(){
-              bombsVisible = !bombsVisible;
-              const bombBtns = document.querySelectorAll('.score-bomb-btn[data-scenario-idx]');
-              bombBtns.forEach(btn => {
-                btn.style.display = bombsVisible ? '' : 'none';
+            bombToggle.setAttribute('aria-pressed', 'false');
+            bombToggle.title = 'Löschen-Buttons einblenden';
+            bombToggle.setAttribute('aria-label', 'Löschen-Buttons einblenden');
+            if(!bombToggle.dataset.bound){
+              bombToggle.addEventListener('click', function(){
+                const isActive = this.getAttribute('aria-pressed') === 'true';
+                const nextState = !isActive;
+                const bombBtns = document.querySelectorAll('.score-bomb-btn[data-scenario-idx]');
+                bombBtns.forEach(btn => {
+                  btn.style.display = nextState ? '' : 'none';
+                });
+                this.setAttribute('aria-pressed', nextState ? 'true' : 'false');
+                const label = nextState ? 'Löschen-Buttons ausblenden' : 'Löschen-Buttons einblenden';
+                this.title = label;
+                this.setAttribute('aria-label', label);
               });
-              bombToggle.setAttribute('aria-pressed', bombsVisible ? 'true' : 'false');
-              bombToggle.title = bombsVisible ? 'Löschen-Buttons ausblenden' : 'Löschen-Buttons einblenden';
+              bombToggle.dataset.bound = 'true';
+            }
+            const bombBtns = document.querySelectorAll('.score-bomb-btn[data-scenario-idx]');
+            bombBtns.forEach(btn => {
+              btn.style.display = 'none';
             });
           }
         }, 0);

--- a/troubleshooter/code/styles.css
+++ b/troubleshooter/code/styles.css
@@ -451,8 +451,8 @@ details[open].hintbox summary::before, details[open].didaktik summary::before{
 .action-message.top-modal{position:fixed;top:48px;left:50%;transform:translateX(-50%);max-width:720px;width:calc(100% - 48px);z-index:999;background:linear-gradient(180deg,#101c38,#0b1223);border-color:#1f2937;box-shadow:0 18px 40px rgba(15,23,42,.6);padding:18px 24px 24px}
 .action-message.top-modal.open{display:grid;grid-template-columns:1fr;grid-template-rows:auto 1fr auto;row-gap:10px}
 .action-message.top-modal .mhead{grid-column:1;grid-row:1;margin-bottom:4px;display:flex;align-items:center;gap:12px}
-.modal-close{
-  margin-left:auto;
+.modal-close,
+.modal-icon-btn{
   width:32px;
   height:32px;
   border-radius:50%;
@@ -466,9 +466,18 @@ details[open].hintbox summary::before, details[open].didaktik summary::before{
   justify-content:center;
   cursor:pointer;
 }
-.modal-close:hover{
+.modal-close{margin-left:auto}
+.modal-close:hover,
+.modal-icon-btn:hover{
   background:linear-gradient(135deg, rgba(59,130,246,.4), rgba(14,116,144,.4));
 }
+.modal-icon-btn .emoji{pointer-events:none;font-size:18px}
+.modal-icon-btn[aria-pressed="true"]{
+  background:linear-gradient(135deg, rgba(59,130,246,.55), rgba(14,116,144,.6));
+  border-color:rgba(96,165,250,.6);
+}
+.action-message.top-modal .modal-close{margin-left:0}
+.action-message.top-modal .modal-icon-btn{margin-left:auto}
 .action-message.top-modal .modal-title-main{font-size:18px;font-weight:700;color:var(--ink)}
 .action-message.top-modal .modal-title-sub{font-size:.95rem;color:var(--ink-dim);font-weight:500;margin-left:auto;text-align:right;padding-left:24px}
 .action-message.top-modal .modal-title-sub.only{margin-left:0;padding-left:0;text-align:left}


### PR DESCRIPTION
## Summary
- move the score reset toggle button into the score modal header next to the close control
- update the modal icon styling so the toggle shares the round design and adds an active state

## Testing
- Manual verification in the browser

------
https://chatgpt.com/codex/tasks/task_e_68e93bf795a48332ab93016c6f9b3fdb